### PR TITLE
Resolve two issues with the Command Interface

### DIFF
--- a/Model/Command/UploadHistoricalOrders.php
+++ b/Model/Command/UploadHistoricalOrders.php
@@ -17,6 +17,11 @@ class UploadHistoricalOrders extends Command
     const BATCH_SIZE = 10;
 
     /**
+     * @var \Magento\Framework\App\State
+     */
+    protected $_state;
+
+    /**
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
      */
     protected $_scopeConfig;
@@ -72,7 +77,7 @@ class UploadHistoricalOrders extends Command
         \Magento\Framework\Api\SearchCriteria $searchCriteriaBuilder,
         Helper $helper
     ) {
-        $state->setAreaCode('adminhtml');
+        $this->_state = $state;
 
         $this->_scopeConfig             = $scopeConfig;
         $this->_orderRepository         = $orderRepository;
@@ -102,6 +107,10 @@ class UploadHistoricalOrders extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+
+        if (!$this->_state->getAreaCode()) {
+            $this->_state->setAreaCode('adminhtml');
+        }
 
         $authToken = $this->_scopeConfig->getValue('riskified/riskified/key', \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
         $env = constant('\Riskified\Common\Env::' . $this->_scopeConfig->getValue('riskified/riskified/env'));

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -26,7 +26,7 @@
         <plugin name="riskified_decider_sales_order_view_toolbar_send_button"
                 type="Riskified\Decider\Plugin\Widget\Context" sortOrder="1"/>
     </type>
-    <type name="Magento\Framework\Console\CommandList">
+    <type name="Magento\Framework\Console\CommandListInterface">
         <arguments>
             <argument name="commands" xsi:type="array">
                 <item name="riskfied_send_historical_orders" xsi:type="object">Riskified\Decider\Model\Command\UploadHistoricalOrders</item>


### PR DESCRIPTION
1. `etc/di.xml` had a typo(?) using `CommandList` rather than `CommandListInterface`
2. `Model\Command\UploadHistoricalOrders.php` improperly set/referenced the `\Magento\Framework\App\State`