### PR TITLE
Save orders with state processing after autoinvoice

### DIFF
--- a/Model/Observer/AutoInvoice.php
+++ b/Model/Observer/AutoInvoice.php
@@ -195,9 +195,7 @@ class AutoInvoice implements ObserverInterface
         }
         try {
             $this->invoiceRepository->save($invoice);
-            if($order->getState() != OrderEntity::STATE_PROCESSING) {
-                $this->orderRepository->save($invoice->getOrder());
-            }
+            $this->orderRepository->save($invoice->getOrder());
         } catch (\Exception $e) {
             $this->logger->addCritical(
                 sprintf(


### PR DESCRIPTION
version: 1.9.2 on Magento 2.4.2

All the operations on order model happening when auto-invoicing a order with state processing are lost because no one saves it.

Module configuration to reproduce:
- Auto-Invoice: enable
- Approved State: processing

Current effect of approval:
- order is in processing state
- order has invoice
- order totals about invoice are untouched (total_paid, total_invoiced, ...)

Expected effect of approval:
- order is in processing state
- order has invoice
- order totals about invoice have been updated (total_paid, total_invoiced, ...)
