### PR TITLE
TIS-370 Added observer to save bin, added bin to api paylad

### DIFF
--- a/Model/Api/Order/PaymentProcessor/Authcim.php
+++ b/Model/Api/Order/PaymentProcessor/Authcim.php
@@ -12,6 +12,7 @@ class Authcim extends AbstractPayment
         $details = [];
         $details['avs_result_code'] = $this->payment->getAdditionalInformation('avs_result_code');
         $details['cvv_result_code'] = $this->payment->getAdditionalInformation('card_code_response_code');
+        $details['credit_card_bin'] = $this->payment->getAdditionalInformation('riskified_cc_bin');
 
         return $details;
     }

--- a/Model/Observer/ImportDataBefore.php
+++ b/Model/Observer/ImportDataBefore.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Riskified\Decider\Model\Observer;
+
+use Magento\Framework\Event\ObserverInterface;
+
+class ImportDataBefore implements ObserverInterface
+{
+    private $registry;
+
+    /**
+     * ImportDataBefore constructor.
+     */
+    public function __construct(
+        \Magento\Framework\Registry $registry
+    ) {
+        $this->registry = $registry;
+    }
+
+    /**
+     * @param \Magento\Framework\Event\Observer $observer
+     */
+    public function execute(\Magento\Framework\Event\Observer $observer)
+    {
+        $additionalData = $observer->getInput()->getAdditionalData();
+
+        if ($additionalData && is_array($additionalData)) {
+            if (isset($additionalData['cc_bin']) && $additionalData['cc_bin']) {
+                $this->registry->unregister('riskified_cc_bin');
+                $this->registry->register('riskified_cc_bin', $additionalData['cc_bin']);
+
+                $observer->getPayment()->setAdditionalInformation('riskified_cc_bin', $additionalData['cc_bin']);
+
+                return $this;
+            }
+        }
+    }
+}

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -21,4 +21,7 @@
         <observer name="riskified_decider_sales_order_save_after"
                   instance="Riskified\Decider\Model\Observer\OrderSaveAfter"/>
     </event>
+    <event name="sales_quote_payment_import_data_before">
+        <observer name="riskified_decider_sales_quote_payment_import_data_before" instance="Riskified\Decider\Model\Observer\ImportDataBefore"/>
+    </event>
 </config>

--- a/etc/frontend/events.xml
+++ b/etc/frontend/events.xml
@@ -14,6 +14,9 @@
     <event name="riskified_decider_order_update_approved">
         <observer name="riskified_decider_order_update_approved" instance="Riskified\Decider\Model\Observer\AutoInvoice"/>
     </event>
+    <event name="sales_quote_payment_import_data_before">
+        <observer name="riskified_decider_sales_quote_payment_import_data_before" instance="Riskified\Decider\Model\Observer\ImportDataBefore"/>
+    </event>
     <event name="riskified_decider_order_update_captured">
         <observer name="riskified_decider_order_update_captured" instance="Riskified\Decider\Model\Observer\AutoInvoice"/>
     </event>


### PR DESCRIPTION
Created observer that it called before magento collect it's payment info data
We have BIN sent to magento in payment-information post call. Thanks to this, we're able to save this bin value in database and populate it in Riskified calls.