### PR TITLE
TIS-460 Fixed support on php 8.1

### DIFF
--- a/Model/Api/Log.php
+++ b/Model/Api/Log.php
@@ -75,7 +75,7 @@ class Log
      */
     public function log($message)
     {
-        $this->_logger->addInfo($message);
+        $this->_logger->info($message);
     }
 
     /**

--- a/Model/Api/Merchant.php
+++ b/Model/Api/Merchant.php
@@ -90,24 +90,24 @@ class Merchant
     public function update($settings)
     {
         $transport = $this->_api->getTransport();
-        $this->logger->addInfo('Merchant::Update');
+        $this->logger->info('Merchant::Update');
         try {
             $response = $transport->updateMerchantSettings($settings);
-            $this->logger->addInfo(__('Merchant Settings posted successfully'));
+            $this->logger->info(__('Merchant Settings posted successfully'));
         } catch (UnsuccessfulActionException $uae) {
             if ($uae->statusCode == '401') {
-                $this->logger->addCritical($uae);
+                $this->logger->critical($uae);
                 $this->_messageManager->addError(
                     __('Make sure you have the correct Auth token as it appears in Riskified advanced settings.')
                 );
             }
             throw $uae;
         } catch (CurlException $curlException) {
-            $this->logger->addCritical($curlException);
+            $this->logger->critical($curlException);
             $this->_messageManager->addError(__('Riskified extension: %s', $curlException->getMessage()));
             throw $curlException;
         } catch (\Exception $e) {
-            $this->logger->addCritical($e);
+            $this->logger->critical($e);
             $this->_messageManager->addError('Riskified extension: ' . $e->getMessage());
             throw $e;
         }

--- a/Model/Api/Order.php
+++ b/Model/Api/Order.php
@@ -149,11 +149,13 @@ class Order
                     break;
                 case Api::ACTION_UPDATE:
                     $orderForTransport = $this->load($order);
+
                     $this->logger->log(serialize($orderForTransport));
                     $response = $transport->updateOrder($orderForTransport);
                     break;
                 case Api::ACTION_SUBMIT:
                     $orderForTransport = $this->load($order);
+
                     $this->logger->log(serialize($orderForTransport));
                     $response = $transport->submitOrder($orderForTransport);
                     break;
@@ -258,7 +260,7 @@ class Order
         $refund = new Model\Refund();
         $refund->id = strval($this->_orderHelper->getOrderOrigId());
         $refundDetails = $this->_orderHelper->getRefundDetails();
-        $refund->refunds = array_filter($refundDetails, 'strlen');
+        $refund->refunds = array_filter($refundDetails, fn ($val) => $val !== null || $val !== false);
 
         return $refund;
     }
@@ -298,8 +300,8 @@ class Order
             unset($order_array['browser_ip']);
             unset($order_array['cart_token']);
         }
-        $payload = array_filter($order_array, 'strlen');
-// var_dump($payload);
+        $payload = array_filter($order_array, fn ($val) => $val !== null || $val !== false);
+
         $order = new Model\Checkout($payload);
 
         $order->customer = $this->_orderHelper->getCustomer();
@@ -323,6 +325,7 @@ class Order
     {
         /** @var \Magento\Sales\Api\Data\OrderInterface $model */
         $gateway = 'unavailable';
+
         if ($model->getPayment()) {
             $gateway = $model->getPayment()->getMethod();
         }
@@ -363,7 +366,9 @@ class Order
             $order_array['source'] = 'desktop_web';
         }
 
-        $order = new Model\Order(array_filter($order_array, 'strlen'));
+        $order = new Model\Order(
+            array_filter($order_array, fn ($val) => $val !== null || $val !== false)
+        );
         $order->customer = $this->_orderHelper->getCustomer();
         $order->shipping_address = $this->_orderHelper->getShippingAddress();
         $order->billing_address = $this->_orderHelper->getBillingAddress();

--- a/Model/Api/Order/Helper.php
+++ b/Model/Api/Order/Helper.php
@@ -2,20 +2,19 @@
 
 namespace Riskified\Decider\Model\Api\Order;
 
-use Riskified\Decider\Model\Api\Order\PaymentProcessor\AbstractPayment;
-use Riskified\OrderWebhook\Model;
 use Magento\Catalog\Api\CategoryRepositoryInterface;
+use Magento\Customer\Model\Customer;
+use Magento\Customer\Model\ResourceModel\GroupRepository;
 use Magento\Framework\App\State;
-use Magento\Framework\Locale\ResolverInterface;
 use Magento\Framework\HTTP\Header;
-use Magento\Framework\Registry;
-use Riskified\Decider\Model\Api\Config as ApiConfig;
+use Magento\Framework\Locale\ResolverInterface;
 use Magento\Framework\Logger\Monolog;
 use Magento\Framework\Message\ManagerInterface;
-use Magento\Customer\Model\Customer;
+use Magento\Framework\Registry;
 use Magento\Sales\Model\ResourceModel\Order\CollectionFactory as OrderCollectionFactory;
 use Magento\Store\Model\StoreManagerInterface;
-use Magento\Customer\Model\ResourceModel\GroupRepository;
+use Riskified\Decider\Model\Api\Config as ApiConfig;
+use Riskified\OrderWebhook\Model;
 
 class Helper
 {
@@ -195,10 +194,10 @@ class Helper
         $code = $this->getOrder()->getDiscountDescription();
         $amount = $this->getOrder()->getDiscountAmount();
         if ($amount && $code) {
-            return new Model\DiscountCode(array_filter(array(
+            return new Model\DiscountCode(array_filter([
                 'code' => $code,
                 'amount' => $amount
-            )));
+            ]));
         }
 
         return null;
@@ -227,10 +226,10 @@ class Helper
      */
     public function getClientDetails()
     {
-        return new Model\ClientDetails(array_filter(array(
+        return new Model\ClientDetails(array_filter([
             'accept_language' => $this->localeResolver->getLocale(),
             'user_agent' => $this->httpHeader->getHttpUserAgent()
-        ), 'strlen'));
+        ], fn ($val) => $val !== null || $val !== false));
     }
 
     /**
@@ -247,7 +246,7 @@ class Helper
             'last_name' => $this->getOrder()->getCustomerLastname(),
             'note' => $this->getOrder()->getCustomerNote(),
         );
-        
+
         if ($customer_id) {
             $customer_details = $this->customer->load($customer_id);
             $customer_props['created_at'] = $this->formatDateAsIso8601($customer_details->getCreatedAt());
@@ -269,7 +268,7 @@ class Helper
                 $this->_messageManager->addError('Riskified extension: ' . $e->getMessage());
             }
         }
-        return new Model\Customer(array_filter($customer_props, 'strlen'));
+        return new Model\Customer(array_filter($customer_props, fn ($val) => $val !== null || $val !== false));
     }
 
     /**
@@ -303,7 +302,7 @@ class Helper
      */
     public function getAllLineItems($object = null)
     {
-        $line_items = array();
+        $line_items = [];
 
         if ($object === null) {
             $object = $this->getOrder();
@@ -381,7 +380,7 @@ class Helper
             $prod_type = "digital";
         }
 
-        $line_item = new Model\LineItem(array_filter(array(
+        $lineItem = [
             'price' => floatval($item->getPrice()),
             'quantity' => !$item->getQtyOrdered() ? intval($item->getQty()) : intval($item->getQtyOrdered()),
             'title' => $item->getName(),
@@ -393,7 +392,9 @@ class Helper
             'category' => (isset($categories) && !empty($categories)) ? implode('|', $categories) : '',
             'sub_category' => (isset($sub_categories) && !empty($sub_categories)) ? implode('|', $sub_categories) : '',
             'requires_shipping' => (bool)!$item->getIsVirtual()
-        ), 'strlen'));
+        ];
+
+        $line_item = new Model\LineItem($lineItem, fn ($val) => $val !== null || $val !== false);
 
         return $line_item;
     }
@@ -430,12 +431,12 @@ class Helper
             'province' => $address->getRegion(),
             'zip' => $address->getPostcode(),
             'phone' => $address->getTelephone(),
-        ), 'strlen');
+        ), fn ($val) => $val !== null || $val !== false);
 
         if (!$addrArray) {
             return null;
         }
-        return new Model\Address($addrArray);
+        return new Model\Address(array_filter($addrArray, fn ($val) => $val !== null || $val !== false));
     }
 
     /**
@@ -455,8 +456,7 @@ class Helper
                     'currency' => $memo['base_currency_code'],
                     'refunded_at' => $memo['created_at'],
                     'reason' => $memo['customer_note']
-                ], 'strlen'));
-
+                ], fn ($val) => $val !== null || $val !== false));
             }
         }
 
@@ -493,7 +493,7 @@ class Helper
         if (isset($paymentProcessor)
             && $paymentProcessor instanceof \Riskified\Decider\Model\Api\Order\PaymentProcessor\Paypal
         ) {
-            return new Model\PaymentDetails(array_filter(array(
+            return new Model\PaymentDetails(array_filter([
                 'authorization_id' => $paymentData['transaction_id'],
                 'payer_email' => $paymentData['payer_email'],
                 'payer_status' => isset($paymentData['payer_status']) ? $paymentData['payer_status'] : '',
@@ -501,13 +501,13 @@ class Helper
                 'protection_eligibility' => $paymentData['protection_eligibility'],
                 'payment_status' => $paymentData['payment_status'],
                 'pending_reason' => $paymentData['pending_reason']
-            ), 'strlen'));
+            ], fn ($val) => $val !== null || $val !== false));
         }
 
-          if (isset($paymentProcessor)
+        if (isset($paymentProcessor)
             && $paymentProcessor instanceof \Riskified\Decider\Model\Api\Order\PaymentProcessor\AdyenHpp && strtolower($payment->getCcType()) == "paypal"
         ) {
-            return new Model\PaymentDetails(array_filter(array(
+            return new Model\PaymentDetails(array_filter([
                 'authorization_id' => $paymentData['transaction_id'],
                 'payer_email' => $paymentData['payer_email'],
                 'payer_status' => isset($paymentData['payer_status']) ? $paymentData['payer_status'] : '',
@@ -515,17 +515,17 @@ class Helper
                 'protection_eligibility' => $paymentData['protection_eligibility'],
                 'payment_status' => $paymentData['payment_status'],
                 'pending_reason' => $paymentData['pending_reason']
-            ), 'strlen'));
+            ], fn ($val) => $val !== null || $val !== false));
         }
 
-        return new Model\PaymentDetails(array_filter(array(
+        return new Model\PaymentDetails(array_filter([
             'authorization_id' => $paymentData['transaction_id'],
             'avs_result_code' => $paymentData['avs_result_code'],
             'cvv_result_code' => $paymentData['cvv_result_code'],
             'credit_card_number' => $paymentData['credit_card_number'],
             'credit_card_company' => $paymentData['credit_card_company'],
             'credit_card_bin' => $paymentData['credit_card_bin']
-        ), 'strlen'));
+        ], fn ($val) => $val !== null || $val !== false));
     }
 
     /**
@@ -659,6 +659,11 @@ class Helper
             ", x-forwarded-ip: " . $this->getOrder()->getXForwardedFor());
 
         $forwardedIp = $this->getOrder()->getXForwardedFor();
+
+        if (empty($forwardedIp)) {
+            return null;
+        }
+
         $forwardeds = preg_split("/,/", $forwardedIp, -1, PREG_SPLIT_NO_EMPTY);
         if (!empty($forwardeds)) {
             return trim($forwardeds[0]);

--- a/Model/Api/Order/Log.php
+++ b/Model/Api/Order/Log.php
@@ -27,43 +27,43 @@ class Log
      */
     public function payment($model)
     {
-        $this->_logger->addInfo("Payment info debug Logs:");
+        $this->_logger->info("Payment info debug Logs:");
         try {
             $payment = $model->getPayment();
             $gateway_name = $payment->getMethod();
-            $this->_logger->addInfo("Payment Gateway: " . $gateway_name);
-            $this->_logger->addInfo("payment->getCcLast4(): " . $payment->getCcLast4());
-            $this->_logger->addInfo("payment->getCcType(): " . $payment->getCcType());
-            $this->_logger->addInfo("payment->getCcCidStatus(): " . $payment->getCcCidStatus());
-            $this->_logger->addInfo("payment->getCcAvsStatus(): " . $payment->getCcAvsStatus());
-            $this->_logger->addInfo("payment->getAdditionalInformation(): " . PHP_EOL . var_export($payment->getAdditionalInformation(), 1));
+            $this->_logger->info("Payment Gateway: " . $gateway_name);
+            $this->_logger->info("payment->getCcLast4(): " . $payment->getCcLast4());
+            $this->_logger->info("payment->getCcType(): " . $payment->getCcType());
+            $this->_logger->info("payment->getCcCidStatus(): " . $payment->getCcCidStatus());
+            $this->_logger->info("payment->getCcAvsStatus(): " . $payment->getCcAvsStatus());
+            $this->_logger->info("payment->getAdditionalInformation(): " . PHP_EOL . var_export($payment->getAdditionalInformation(), 1));
             $sage = $model->getSagepayInfo();
 
             if (is_object($sage)) {
-                $this->_logger->addInfo("sagepay->getLastFourDigits(): " . $sage->getLastFourDigits());
-                $this->_logger->addInfo("sagepay->last_four_digits: " . $sage->getData('last_four_digits'));
-                $this->_logger->addInfo("sagepay->getCardType(): " . $sage->getCardType());
-                $this->_logger->addInfo("sagepay->card_type: " . $sage->getData('card_type'));
-                $this->_logger->addInfo("sagepay->getAvsCv2Status: " . $sage->getAvsCv2Status());
-                $this->_logger->addInfo("sagepay->address_result: " . $sage->getData('address_result'));
-                $this->_logger->addInfo("sagepay->getCv2result: " . $sage->getCv2result());
-                $this->_logger->addInfo("sagepay->cv2result: " . $sage->getData('cv2result'));
-                $this->_logger->addInfo("sagepay->getAvscv2: " . $sage->getAvscv2());
-                $this->_logger->addInfo("sagepay->getAddressResult: " . $sage->getAddressResult());
-                $this->_logger->addInfo("sagepay->getPostcodeResult: " . $sage->getPostcodeResult());
-                $this->_logger->addInfo("sagepay->getDeclineCode: " . $sage->getDeclineCode());
-                $this->_logger->addInfo("sagepay->getBankAuthCode: " . $sage->getBankAuthCode());
-                $this->_logger->addInfo("sagepay->getPayerStatus: " . $sage->getPayerStatus());
+                $this->_logger->info("sagepay->getLastFourDigits(): " . $sage->getLastFourDigits());
+                $this->_logger->info("sagepay->last_four_digits: " . $sage->getData('last_four_digits'));
+                $this->_logger->info("sagepay->getCardType(): " . $sage->getCardType());
+                $this->_logger->info("sagepay->card_type: " . $sage->getData('card_type'));
+                $this->_logger->info("sagepay->getAvsCv2Status: " . $sage->getAvsCv2Status());
+                $this->_logger->info("sagepay->address_result: " . $sage->getData('address_result'));
+                $this->_logger->info("sagepay->getCv2result: " . $sage->getCv2result());
+                $this->_logger->info("sagepay->cv2result: " . $sage->getData('cv2result'));
+                $this->_logger->info("sagepay->getAvscv2: " . $sage->getAvscv2());
+                $this->_logger->info("sagepay->getAddressResult: " . $sage->getAddressResult());
+                $this->_logger->info("sagepay->getPostcodeResult: " . $sage->getPostcodeResult());
+                $this->_logger->info("sagepay->getDeclineCode: " . $sage->getDeclineCode());
+                $this->_logger->info("sagepay->getBankAuthCode: " . $sage->getBankAuthCode());
+                $this->_logger->info("sagepay->getPayerStatus: " . $sage->getPayerStatus());
             }
             if ($gateway_name == "optimal_hosted") {
                 $optimalTransaction = unserialize($payment->getAdditionalInformation('transaction'));
                 if ($optimalTransaction) {
-                    $this->_logger->addInfo("Optimal transaction: ");
-                    $this->_logger->addInfo("transaction->cvdVerification: " . $optimalTransaction->cvdVerification);
-                    $this->_logger->addInfo("transaction->houseNumberVerification: " . $optimalTransaction->houseNumberVerification);
-                    $this->_logger->addInfo("transaction->zipVerification: " . $optimalTransaction->zipVerification);
+                    $this->_logger->info("Optimal transaction: ");
+                    $this->_logger->info("transaction->cvdVerification: " . $optimalTransaction->cvdVerification);
+                    $this->_logger->info("transaction->houseNumberVerification: " . $optimalTransaction->houseNumberVerification);
+                    $this->_logger->info("transaction->zipVerification: " . $optimalTransaction->zipVerification);
                 } else {
-                    $this->_logger->addInfo("Optimal gateway but no transaction found");
+                    $this->_logger->info("Optimal gateway but no transaction found");
                 }
             }
         } catch (\Exception $e) {
@@ -95,7 +95,7 @@ class Log
      */
     public function log($message)
     {
-        $this->_logger->addInfo($message);
+        $this->_logger->info($message);
     }
 
     /**
@@ -103,6 +103,6 @@ class Log
      */
     public function logException($message)
     {
-        $this->_logger->addCritical($message);
+        $this->_logger->critical($message);
     }
 }

--- a/Model/Command/UploadHistoricalOrders.php
+++ b/Model/Command/UploadHistoricalOrders.php
@@ -238,7 +238,7 @@ class UploadHistoricalOrders extends Command
             'vendor_name' => $model->getStoreName(),
         );
 
-        $order = new Model\Order(array_filter($order_array, 'strlen'));
+        $order = new Model\Order($order_array, fn ($val) => $val !== null || $val !== false);
         $order->customer = $this->_orderHelper->getCustomer();
         $order->shipping_address = $this->_orderHelper->getShippingAddress();
         $order->billing_address = $this->_orderHelper->getBillingAddress();

--- a/Model/Cron/Submission.php
+++ b/Model/Cron/Submission.php
@@ -80,7 +80,7 @@ class Submission
             return;
         }
 
-        $this->logger->addInfo("Retrying failed order submissions");
+        $this->logger->info("Retrying failed order submissions");
 
         $retries = $this->queue->getCollection()
             ->addFieldToFilter(
@@ -111,7 +111,7 @@ class Submission
         $collection = $this->orderFactory->create()->addFieldToFilter('entity_id', array('in' => $orderIds));
 
         foreach ($collection as $order) {
-            $this->logger->addInfo("Retrying order " . $order->getId());
+            $this->logger->info("Retrying order " . $order->getId());
 
             try {
                 $this->api->post($order, $mapperOrder[$order->getId()]->getAction());
@@ -126,6 +126,6 @@ class Submission
             }
         }
 
-        $this->logger->addInfo("Done retrying failed order submissions");
+        $this->logger->info("Done retrying failed order submissions");
     }
 }

--- a/Model/Observer/AutoInvoice.php
+++ b/Model/Observer/AutoInvoice.php
@@ -137,7 +137,7 @@ class AutoInvoice implements ObserverInterface
         if (!$order || !$order->getId()) {
             return false;
         }
-        $this->logger->addInfo(
+        $this->logger->info(
             sprintf(
                 __('Auto-invoicing  order #%s'),
                 $order->getIncrementId()
@@ -147,7 +147,7 @@ class AutoInvoice implements ObserverInterface
         if (!$order->canInvoice()
             || $order->getState() != OrderEntity::STATE_PROCESSING
         ) {
-            $this->logger->addInfo('Order cannot be invoiced');
+            $this->logger->info('Order cannot be invoiced');
             if ($this->apiConfig->isLoggingEnabled()) {
                 $this->apiOrderLogger->logInvoice($order);
             }
@@ -162,7 +162,7 @@ class AutoInvoice implements ObserverInterface
         );
 
         if (!$invoice->getTotalQty()) {
-            $this->logger->addInfo(
+            $this->logger->info(
                 __('Cannot create an invoice without products')
             );
 
@@ -185,7 +185,7 @@ class AutoInvoice implements ObserverInterface
                 [$invoice, 'register']
             );
         } catch (\Exception $e) {
-            $this->logger->addInfo(
+            $this->logger->info(
                 sprintf(
                     __("Error creating invoice: %s"),
                     $e->getMessage()
@@ -208,7 +208,7 @@ class AutoInvoice implements ObserverInterface
 
             return false;
         }
-        $this->logger->addInfo(
+        $this->logger->info(
             __("Transaction saved")
         );
     }

--- a/composer.json
+++ b/composer.json
@@ -1,16 +1,19 @@
 {
-  "name": "riskified/magento2new",
-  "type": "magento2-module",
-  "description": "Riskified decider module for Magento 2",
-  "version": "1.10.1",
-  "require": {
-    "magento/framework": ">=100.1.0",
-    "riskified/php_sdk": "*"
-  },
-  "autoload": {
-    "files": ["registration.php"],
-    "psr-4": {
-      "Riskified\\Decider\\": ""
+    "name": "riskified/magento2new",
+    "type": "magento2-module",
+    "description": "Riskified decider module for Magento 2",
+    "version": "1.10.1",
+    "require": {
+        "php": ">=7.4",
+        "magento/framework": ">=100.1.0",
+        "riskified/php_sdk": "*"
+    },
+    "autoload": {
+        "files": [
+            "registration.php"
+        ],
+        "psr-4": {
+            "Riskified\\Decider\\": ""
+        }
     }
-  }
 }


### PR DESCRIPTION
In PHP 8.1, `strlen` function is reporting warning when value passed is `null`.

Proposed function will work in similar way.
We may merge this to master, but we have to make sure that store is running on PHP at least `7.4` (used arrow functions were implemented in this version). Added php version as requirement in `composer.json` file

Changed `addInfo` to `info` to suppress magento 2.4.x errors. 
