### PR TITLE
TIS-483 - Set correct api settings when send order placed in admin

### DIFF
--- a/Model/Api/Order.php
+++ b/Model/Api/Order.php
@@ -131,11 +131,13 @@ class Order
             return $this;
         }
 
-        $transport = $this->_api->getTransport();
-
         if (!$order) {
             throw new \Exception("Order doesn't not exists");
         }
+
+        $this->_api->initSdk($order);
+        $transport = $this->_api->getTransport();
+
         $this->_orderHelper->setOrder($order);
         $eventData = [
             'order' => $order,


### PR DESCRIPTION
When handling multi store and order is placed in admin panel, default Riskified account was selected.
Provided fix is initializing SDK again and base on order `store ID`, correct Riskified account will be selected.