### PR TITLE
TIS-499 Added compatibility with PHP 7.4

### DIFF
--- a/Api/Data/DecisionInterface.php
+++ b/Api/Data/DecisionInterface.php
@@ -46,7 +46,7 @@ interface DecisionInterface
      * @param int $attemptsCount
      * @return mixed
      */
-    public function setAttemptsCount(int $attemptsCount): mixed;
+    public function setAttemptsCount(int $attemptsCount);
 
     /**
      * @return int

--- a/Controller/Response/Get.php
+++ b/Controller/Response/Get.php
@@ -38,7 +38,15 @@ class Get extends \Magento\Framework\App\Action\Action
      * @var Config
      */
     private $config;
+    /**
+     * @var DecisionRepositoryInterface
+     */
     private $decisionRepository;
+
+    /**
+     * @var DecisionFactory
+     */
+    private DecisionFactory $decisionFactory;
 
     /**
      * Get constructor.
@@ -55,7 +63,7 @@ class Get extends \Magento\Framework\App\Action\Action
         LogApi $apiLogger,
         Config $config,
         DecisionFactory $decisionFactory,
-        DecisionRepositoryInterface $decisionRepository,
+        DecisionRepositoryInterface $decisionRepository
     ) {
         parent::__construct($context);
         $this->api = $api;

--- a/Model/Api/Decision.php
+++ b/Model/Api/Decision.php
@@ -75,7 +75,7 @@ class Decision extends AbstractExtensibleModel implements DecisionInterface
      * @param int $attemptsCount
      * @return mixed
      */
-    public function setAttemptsCount(int $attemptsCount): mixed
+    public function setAttemptsCount(int $attemptsCount)
     {
         return $this->setData('attempts_count', $attemptsCount);
     }


### PR DESCRIPTION
Removed `mixed` return type as it's not supported in this PHP version
Fixed `GetController` constructor