### PR TITLE
Update in code for php8.2 support and API code 

### DIFF
--- a/Model/Api/Order.php
+++ b/Model/Api/Order.php
@@ -135,12 +135,12 @@ class Order
      */
     public function post($order, $action)
     {
-        if (!$this->_apiConfig->isEnabled($order->getStoreId())) {
-            return $this;
-        }
-
         if (!$order) {
             throw new \Exception("Order doesn't not exists");
+        }
+        
+        if (!$this->_apiConfig->isEnabled($order->getStoreId())) {
+            return $this;
         }
 
         $this->_api->initSdk($order);
@@ -398,11 +398,11 @@ class Order
      */
     public function update($order, $status, $oldStatus, $description)
     {
-        if (!$this->_apiConfig->isEnabled($order->getStoreId())) {
+        if (!$order) {
             return;
         }
 
-        if (!$order) {
+        if (!$this->_apiConfig->isEnabled($order->getStoreId())) {
             return;
         }
 

--- a/Model/Cron/ReleasePendingPaymentOrders.php
+++ b/Model/Cron/ReleasePendingPaymentOrders.php
@@ -56,6 +56,11 @@ class ReleasePendingPaymentOrders
      */
     private Registry $registry;
 
+    /*
+     * @var AutoInvoice
+     */
+    private AutoInvoice $autoInvoiceObserver
+
     /**
      *
      */

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "riskified/magento2new",
     "type": "magento2-module",
     "description": "Riskified decider module for Magento 2",
-    "version": "1.12.11",
+    "version": "1.12.12",
     "require": {
         "php": ">=7.4",
         "magento/framework": ">=100.1.0",


### PR DESCRIPTION
There is api function post and update in Model/Api/Order.php file where api config enable is checked by store id but if we don't have order then it will not executing so first we have to check order is available or no for that i have updated code according that.